### PR TITLE
Added throttle method for promises

### DIFF
--- a/__tests__/promises.test.ts
+++ b/__tests__/promises.test.ts
@@ -1,140 +1,140 @@
 const { sleep, timeout, race, TimeoutErrors, throttle } = require("@/promises");
 
 describe("sleep", () => {
-    test("sleeps for half a second passing 500", async () => {
-        const start: Date = new Date();
-        await sleep(500);
-        const end: Date = new Date();
-        const diff: number = end.getTime() - start.getTime();
-        expect(diff).toBeGreaterThanOrEqual(499);
-    });
+  test("sleeps for half a second passing 500", async () => {
+    const start: Date = new Date();
+    await sleep(500);
+    const end: Date = new Date();
+    const diff: number = end.getTime() - start.getTime();
+    expect(diff).toBeGreaterThanOrEqual(499);
+  });
 
-    test("sleeps for 0.1 seconds passing 100", async () => {
-        const start: Date = new Date();
-        await sleep(100);
-        const end: Date = new Date();
-        const diff: number = end.getTime() - start.getTime();
-        expect(diff).toBeGreaterThanOrEqual(99);
-    });
+  test("sleeps for 0.1 seconds passing 100", async () => {
+    const start: Date = new Date();
+    await sleep(100);
+    const end: Date = new Date();
+    const diff: number = end.getTime() - start.getTime();
+    expect(diff).toBeGreaterThanOrEqual(99);
+  });
 
-    test("sleeps for 1 second without params", async () => {
-        const start: Date = new Date();
-        await sleep();
-        const end: Date = new Date();
-        const diff: number = end.getTime() - start.getTime();
-        expect(diff).toBeGreaterThanOrEqual(999);
-    });
+  test("sleeps for 1 second without params", async () => {
+    const start: Date = new Date();
+    await sleep();
+    const end: Date = new Date();
+    const diff: number = end.getTime() - start.getTime();
+    expect(diff).toBeGreaterThanOrEqual(999);
+  });
 });
 
 function mockResolvedPromise(value: any, time: number) {
-    return new Promise(resolve => setTimeout(() => resolve(value), time));
+  return new Promise(resolve => setTimeout(() => resolve(value), time));
 }
 
 function mockRejectedPromise(error: any, time: number) {
-    return new Promise((_, reject) =>
-        setTimeout(() => reject(new Error(error)), time)
-    );
+  return new Promise((_, reject) =>
+    setTimeout(() => reject(new Error(error)), time)
+  );
 }
 
 describe("Throttle", () => {
-    test("In case of only resolve", async () => {
-        const data = "resolved data";
-        const success = await throttle([
-            () => mockResolvedPromise(data, 100),
-            () => mockResolvedPromise(data, 200),
-            () => mockResolvedPromise(data, 300),
-        ]);
-        expect(success).toEqual([data, data, data]);
-    });
-    test("In case of one rejected", async () => {
-        const data = "resolved data";
-        await expect(() =>
-            throttle([
-                () => mockResolvedPromise(data, 100),
-                () => mockRejectedPromise(TimeoutErrors.RESPONSE_ERROR_MESSAGE, 200),
-                () => mockResolvedPromise(data, 300),
-            ])
-        ).rejects.toThrow(TimeoutErrors.RESPONSE_ERROR_MESSAGE);
-    });
-    test("In case of all rejected", async () => {
-        const data = "resolved data";
-        await expect(() =>
-            throttle([
-                () => mockRejectedPromise(TimeoutErrors.RESPONSE_ERROR_MESSAGE, 200),
-                () => mockRejectedPromise(TimeoutErrors.RESPONSE_ERROR_MESSAGE, 200),
-                () => mockRejectedPromise(TimeoutErrors.RESPONSE_ERROR_MESSAGE, 200),
-            ])
-        ).rejects.toThrow(TimeoutErrors.RESPONSE_ERROR_MESSAGE);
-    });
+  test("In case of only resolve", async () => {
+    const data = "resolved data";
+    const success = await throttle([
+      () => mockResolvedPromise(data, 100),
+      () => mockResolvedPromise(data, 200),
+      () => mockResolvedPromise(data, 300),
+    ]);
+    expect(success).toEqual([data, data, data]);
+  });
+  test("In case of one rejected", async () => {
+    const data = "resolved data";
+    await expect(() =>
+      throttle([
+        () => mockResolvedPromise(data, 100),
+        () => mockRejectedPromise(TimeoutErrors.RESPONSE_ERROR_MESSAGE, 200),
+        () => mockResolvedPromise(data, 300),
+      ])
+    ).rejects.toThrow(TimeoutErrors.RESPONSE_ERROR_MESSAGE);
+  });
+  test("In case of all rejected", async () => {
+    const data = "resolved data";
+    await expect(() =>
+      throttle([
+        () => mockRejectedPromise(TimeoutErrors.RESPONSE_ERROR_MESSAGE, 200),
+        () => mockRejectedPromise(TimeoutErrors.RESPONSE_ERROR_MESSAGE, 200),
+        () => mockRejectedPromise(TimeoutErrors.RESPONSE_ERROR_MESSAGE, 200),
+      ])
+    ).rejects.toThrow(TimeoutErrors.RESPONSE_ERROR_MESSAGE);
+  });
 });
 
 describe("timeout", () => {
-    const data = "resolved data";
+  const data = "resolved data";
 
-    test("In case of only resolve", async () => {
-        const success = await timeout(mockResolvedPromise(data, 100), 300);
-        expect(success).toBe(data);
-    });
+  test("In case of only resolve", async () => {
+    const success = await timeout(mockResolvedPromise(data, 100), 300);
+    expect(success).toBe(data);
+  });
 
-    test("In case of only rejected", async () => {
-        await expect(() =>
-            timeout(
-                mockRejectedPromise(TimeoutErrors.RESPONSE_ERROR_MESSAGE, 100),
-                300
-            )
-        ).rejects.toThrow(new Error(TimeoutErrors.RESPONSE_ERROR_MESSAGE));
-    });
+  test("In case of only rejected", async () => {
+    await expect(() =>
+      timeout(
+        mockRejectedPromise(TimeoutErrors.RESPONSE_ERROR_MESSAGE, 100),
+        300
+      )
+    ).rejects.toThrow(new Error(TimeoutErrors.RESPONSE_ERROR_MESSAGE));
+  });
 
-    test("In case of timeout and resolve", async () => {
-        await expect(() =>
-            timeout(mockResolvedPromise(data, 300), 100)
-        ).rejects.toThrow(new Error(TimeoutErrors.TIMEOUT_ERROR_MESSAGE));
-    });
+  test("In case of timeout and resolve", async () => {
+    await expect(() =>
+      timeout(mockResolvedPromise(data, 300), 100)
+    ).rejects.toThrow(new Error(TimeoutErrors.TIMEOUT_ERROR_MESSAGE));
+  });
 
-    test("In case of timeout and rejected", async () => {
-        await expect(() =>
-            timeout(
-                mockRejectedPromise(TimeoutErrors.RESPONSE_ERROR_MESSAGE, 300),
-                100
-            )
-        ).rejects.toThrow(new Error(TimeoutErrors.TIMEOUT_ERROR_MESSAGE));
-    });
+  test("In case of timeout and rejected", async () => {
+    await expect(() =>
+      timeout(
+        mockRejectedPromise(TimeoutErrors.RESPONSE_ERROR_MESSAGE, 300),
+        100
+      )
+    ).rejects.toThrow(new Error(TimeoutErrors.TIMEOUT_ERROR_MESSAGE));
+  });
 });
 
 describe("race", () => {
-    const sleepForNTime = (time: number) =>
-        new Promise(async resolve => {
-            await sleep(time);
-            return resolve(time);
-        });
-
-    test("should return the first promise as faster", async () => {
-        const first = sleepForNTime(500);
-        const second = sleepForNTime(1000);
-        const third = sleepForNTime(2000);
-
-        const race_winner = await race([first, second, third]);
-
-        expect(race_winner).toBe(500);
+  const sleepForNTime = (time: number) =>
+    new Promise(async resolve => {
+      await sleep(time);
+      return resolve(time);
     });
 
-    test("should return the second promise as faster", async () => {
-        const first = sleepForNTime(1000);
-        const second = sleepForNTime(500);
-        const third = sleepForNTime(2000);
+  test("should return the first promise as faster", async () => {
+    const first = sleepForNTime(500);
+    const second = sleepForNTime(1000);
+    const third = sleepForNTime(2000);
 
-        const race_winner = await race([first, second, third]);
+    const race_winner = await race([first, second, third]);
 
-        expect(race_winner).toBe(500);
-    });
+    expect(race_winner).toBe(500);
+  });
 
-    test("should return the third promise as faster", async () => {
-        const first = sleepForNTime(2000);
-        const second = sleepForNTime(1000);
-        const third = sleepForNTime(500);
+  test("should return the second promise as faster", async () => {
+    const first = sleepForNTime(1000);
+    const second = sleepForNTime(500);
+    const third = sleepForNTime(2000);
 
-        const race_winner = await race([first, second, third]);
+    const race_winner = await race([first, second, third]);
 
-        expect(race_winner).toBe(500);
-    });
+    expect(race_winner).toBe(500);
+  });
+
+  test("should return the third promise as faster", async () => {
+    const first = sleepForNTime(2000);
+    const second = sleepForNTime(1000);
+    const third = sleepForNTime(500);
+
+    const race_winner = await race([first, second, third]);
+
+    expect(race_winner).toBe(500);
+  });
 });

--- a/__tests__/promises.test.ts
+++ b/__tests__/promises.test.ts
@@ -1,122 +1,140 @@
-const { sleep, timeout, race, TimeoutErrors } = require("@/promises");
+const { sleep, timeout, race, TimeoutErrors, throttle } = require("@/promises");
 
 describe("sleep", () => {
-  test("sleeps for half a second passing 500", async () => {
-    const start: Date = new Date();
-    await sleep(500);
-    const end: Date = new Date();
-    const diff: number = end.getTime() - start.getTime();
-    expect(diff).toBeGreaterThanOrEqual(499);
-  });
+    test("sleeps for half a second passing 500", async () => {
+        const start: Date = new Date();
+        await sleep(500);
+        const end: Date = new Date();
+        const diff: number = end.getTime() - start.getTime();
+        expect(diff).toBeGreaterThanOrEqual(499);
+    });
 
-  test("sleeps for 0.1 seconds passing 100", async () => {
-    const start: Date = new Date();
-    await sleep(100);
-    const end: Date = new Date();
-    const diff: number = end.getTime() - start.getTime();
-    expect(diff).toBeGreaterThanOrEqual(99);
-  });
+    test("sleeps for 0.1 seconds passing 100", async () => {
+        const start: Date = new Date();
+        await sleep(100);
+        const end: Date = new Date();
+        const diff: number = end.getTime() - start.getTime();
+        expect(diff).toBeGreaterThanOrEqual(99);
+    });
 
-  test("sleeps for 1 second without params", async () => {
-    const start: Date = new Date();
-    await sleep();
-    const end: Date = new Date();
-    const diff: number = end.getTime() - start.getTime();
-    expect(diff).toBeGreaterThanOrEqual(999);
-  });
+    test("sleeps for 1 second without params", async () => {
+        const start: Date = new Date();
+        await sleep();
+        const end: Date = new Date();
+        const diff: number = end.getTime() - start.getTime();
+        expect(diff).toBeGreaterThanOrEqual(999);
+    });
 });
 
 function mockResolvedPromise(value: any, time: number) {
-  return new Promise(resolve => setTimeout(() => resolve(value), time));
+    return new Promise(resolve => setTimeout(() => resolve(value), time));
 }
 
 function mockRejectedPromise(error: any, time: number) {
-  return new Promise((_, reject) =>
-    setTimeout(() => reject(new Error(error)), time)
-  );
+    return new Promise((_, reject) =>
+        setTimeout(() => reject(new Error(error)), time)
+    );
 }
 
+describe("Throttle", () => {
+    test("In case of only resolve", async () => {
+        const data = "resolved data";
+        const success = await throttle([
+            () => mockResolvedPromise(data, 100),
+            () => mockResolvedPromise(data, 200),
+            () => mockResolvedPromise(data, 300),
+        ]);
+        expect(success).toEqual([data, data, data]);
+    });
+    test("In case of one rejected", async () => {
+        const data = "resolved data";
+        await expect(() =>
+            throttle([
+                () => mockResolvedPromise(data, 100),
+                () => mockRejectedPromise(TimeoutErrors.RESPONSE_ERROR_MESSAGE, 200),
+                () => mockResolvedPromise(data, 300),
+            ])
+        ).rejects.toThrow(TimeoutErrors.RESPONSE_ERROR_MESSAGE);
+    });
+    test("In case of all rejected", async () => {
+        const data = "resolved data";
+        await expect(() =>
+            throttle([
+                () => mockRejectedPromise(TimeoutErrors.RESPONSE_ERROR_MESSAGE, 200),
+                () => mockRejectedPromise(TimeoutErrors.RESPONSE_ERROR_MESSAGE, 200),
+                () => mockRejectedPromise(TimeoutErrors.RESPONSE_ERROR_MESSAGE, 200),
+            ])
+        ).rejects.toThrow(TimeoutErrors.RESPONSE_ERROR_MESSAGE);
+    });
+});
+
 describe("timeout", () => {
-  const data = "resolved data";
+    const data = "resolved data";
 
-  test("In case of only resolve", async () => {
-    const success = await timeout(mockResolvedPromise(data, 100), 300);
-    expect(success).toBe(data);
-  });
+    test("In case of only resolve", async () => {
+        const success = await timeout(mockResolvedPromise(data, 100), 300);
+        expect(success).toBe(data);
+    });
 
-  test("In case of only rejected", async () => {
-    await expect(() =>
-      timeout(
-        mockRejectedPromise(TimeoutErrors.RESPONSE_ERROR_MESSAGE, 100),
-        300
-      )
-    ).rejects.toThrow(new Error(TimeoutErrors.RESPONSE_ERROR_MESSAGE));
-  });
+    test("In case of only rejected", async () => {
+        await expect(() =>
+            timeout(
+                mockRejectedPromise(TimeoutErrors.RESPONSE_ERROR_MESSAGE, 100),
+                300
+            )
+        ).rejects.toThrow(new Error(TimeoutErrors.RESPONSE_ERROR_MESSAGE));
+    });
 
-  test("In case of timeout and resolve", async () => {
-    await expect(() =>
-      timeout(mockResolvedPromise(data, 300), 100)
-    ).rejects.toThrow(new Error(TimeoutErrors.TIMEOUT_ERROR_MESSAGE));
-  });
+    test("In case of timeout and resolve", async () => {
+        await expect(() =>
+            timeout(mockResolvedPromise(data, 300), 100)
+        ).rejects.toThrow(new Error(TimeoutErrors.TIMEOUT_ERROR_MESSAGE));
+    });
 
-  test("In case of timeout and rejected", async () => {
-    await expect(() =>
-      timeout(
-        mockRejectedPromise(TimeoutErrors.RESPONSE_ERROR_MESSAGE, 300),
-        100
-      )
-    ).rejects.toThrow(new Error(TimeoutErrors.TIMEOUT_ERROR_MESSAGE));
-  });
+    test("In case of timeout and rejected", async () => {
+        await expect(() =>
+            timeout(
+                mockRejectedPromise(TimeoutErrors.RESPONSE_ERROR_MESSAGE, 300),
+                100
+            )
+        ).rejects.toThrow(new Error(TimeoutErrors.TIMEOUT_ERROR_MESSAGE));
+    });
 });
 
 describe("race", () => {
-  const sleepForNTime = (time: number) =>
-    new Promise(async resolve => {
-      await sleep(time);
-      return resolve(time);
+    const sleepForNTime = (time: number) =>
+        new Promise(async resolve => {
+            await sleep(time);
+            return resolve(time);
+        });
+
+    test("should return the first promise as faster", async () => {
+        const first = sleepForNTime(500);
+        const second = sleepForNTime(1000);
+        const third = sleepForNTime(2000);
+
+        const race_winner = await race([first, second, third]);
+
+        expect(race_winner).toBe(500);
     });
 
-  test("should return the first promise as faster", async () => {
-    const first = sleepForNTime(500);
-    const second = sleepForNTime(1000);
-    const third = sleepForNTime(2000);
+    test("should return the second promise as faster", async () => {
+        const first = sleepForNTime(1000);
+        const second = sleepForNTime(500);
+        const third = sleepForNTime(2000);
 
-    const race_winner = await race([
-      first,
-      second,
-      third,
-    ]);
+        const race_winner = await race([first, second, third]);
 
-    expect(race_winner).toBe(500);
-  });
+        expect(race_winner).toBe(500);
+    });
 
-  test("should return the second promise as faster", async () => {
-    const first = sleepForNTime(1000);
-    const second = sleepForNTime(500);
-    const third = sleepForNTime(2000);
+    test("should return the third promise as faster", async () => {
+        const first = sleepForNTime(2000);
+        const second = sleepForNTime(1000);
+        const third = sleepForNTime(500);
 
-    const race_winner = await race([
-      first,
-      second,
-      third,
-    ]);
+        const race_winner = await race([first, second, third]);
 
-    expect(race_winner).toBe(500);
-  });
-
-  test("should return the third promise as faster", async () => {
-    const first = sleepForNTime(2000);
-    const second = sleepForNTime(1000);
-    const third = sleepForNTime(500);
-
-    const race_winner = await race([
-      first,
-      second,
-      third,
-    ]);
-
-    expect(race_winner).toBe(500);
-  });
-
-
+        expect(race_winner).toBe(500);
+    });
 });

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "wellon"
     ],
     "dependencies": {
+        "asyncrify": "^0.2.9",
         "file-type": "^16.0.1"
     },
     "devDependencies": {

--- a/src/promises.ts
+++ b/src/promises.ts
@@ -1,10 +1,11 @@
+import Asyncrify from "asyncrify";
 interface TimeoutErrorConstants {
-  [erorr: string]: string;
+    [erorr: string]: string;
 }
 
 const TimeoutErrors: TimeoutErrorConstants = {
-  TIMEOUT_ERROR_MESSAGE: "Timeout Error",
-  RESPONSE_ERROR_MESSAGE: "Response Error",
+    TIMEOUT_ERROR_MESSAGE: "Timeout Error",
+    RESPONSE_ERROR_MESSAGE: "Response Error",
 };
 
 /**
@@ -13,7 +14,34 @@ const TimeoutErrors: TimeoutErrorConstants = {
  * @returns {Promise} - The promise that resolves after the time.
  */
 function sleep(time: number = 1000) {
-  return new Promise(resolve => setTimeout(resolve, time));
+    return new Promise(resolve => setTimeout(resolve, time));
+}
+
+/**
+ * @callback promiseFunction
+ * @return {Promise<T>}
+ */
+
+/**
+ * This method receives an array of functions that returns a promise and a max concurrency
+ * @param {promiseFunction[]} promises - an array of functions that return a promise
+ * @returns {Promise<T[]>} - a promise array of all the promises passed in
+ */
+async function throttle<T>(
+    promises: (() => Promise<T>)[],
+    maxConcurrency: number
+): Promise<T[]> {
+    const returnArray = new Array<Promise<T>>(promises.length);
+    const queue = new Asyncrify(maxConcurrency);
+    for (let i = 0; i < promises.length; i++) {
+        returnArray[i] = new Promise((resolve, reject) => {
+            queue.add(promises[i], (res, err) => {
+                if (err) reject(err);
+                resolve(res);
+            });
+        });
+    }
+    return Promise.all(returnArray);
 }
 
 /**
@@ -26,22 +54,22 @@ function sleep(time: number = 1000) {
  * author: ahn0min - YeongMin Ahn
  */
 function timeout<T>(promise: Promise<T>, time: number = 8000) {
-  return new Promise((resolve, reject) => {
-    const timeout_id = setTimeout(
-      () => reject(new Error(TimeoutErrors.TIMEOUT_ERROR_MESSAGE)),
-      time
-    );
+    return new Promise((resolve, reject) => {
+        const timeout_id = setTimeout(
+            () => reject(new Error(TimeoutErrors.TIMEOUT_ERROR_MESSAGE)),
+            time
+        );
 
-    promise
-      .then(response => {
-        clearTimeout(timeout_id);
-        resolve(response);
-      })
-      .catch(err => {
-        clearTimeout(timeout_id);
-        reject(err);
-      });
-  });
+        promise
+            .then(response => {
+                clearTimeout(timeout_id);
+                resolve(response);
+            })
+            .catch(err => {
+                clearTimeout(timeout_id);
+                reject(err);
+            });
+    });
 }
 
 /**
@@ -51,8 +79,8 @@ function timeout<T>(promise: Promise<T>, time: number = 8000) {
  * @returns {Promise} - The first promise that is resolved.
  */
 async function race<T>(array_of_promises: Promise<T>[]) {
-  const result = await Promise.race(array_of_promises);
-  return result;
+    const result = await Promise.race(array_of_promises);
+    return result;
 }
 
-export { sleep, timeout, race, TimeoutErrors };
+export { sleep, timeout, race, TimeoutErrors, throttle };

--- a/src/promises.ts
+++ b/src/promises.ts
@@ -1,11 +1,11 @@
 import Asyncrify from "asyncrify";
 interface TimeoutErrorConstants {
-    [erorr: string]: string;
+  [erorr: string]: string;
 }
 
 const TimeoutErrors: TimeoutErrorConstants = {
-    TIMEOUT_ERROR_MESSAGE: "Timeout Error",
-    RESPONSE_ERROR_MESSAGE: "Response Error",
+  TIMEOUT_ERROR_MESSAGE: "Timeout Error",
+  RESPONSE_ERROR_MESSAGE: "Response Error",
 };
 
 /**
@@ -14,7 +14,7 @@ const TimeoutErrors: TimeoutErrorConstants = {
  * @returns {Promise} - The promise that resolves after the time.
  */
 function sleep(time: number = 1000) {
-    return new Promise(resolve => setTimeout(resolve, time));
+  return new Promise(resolve => setTimeout(resolve, time));
 }
 
 /**
@@ -28,20 +28,20 @@ function sleep(time: number = 1000) {
  * @returns {Promise<T[]>} - a promise array of all the promises passed in
  */
 async function throttle<T>(
-    promises: (() => Promise<T>)[],
-    maxConcurrency: number
+  promises: (() => Promise<T>)[],
+  maxConcurrency: number
 ): Promise<T[]> {
-    const returnArray = new Array<Promise<T>>(promises.length);
-    const queue = new Asyncrify(maxConcurrency);
-    for (let i = 0; i < promises.length; i++) {
-        returnArray[i] = new Promise((resolve, reject) => {
-            queue.add(promises[i], (res, err) => {
-                if (err) reject(err);
-                resolve(res);
-            });
-        });
-    }
-    return Promise.all(returnArray);
+  const returnArray = new Array<Promise<T>>(promises.length);
+  const queue = new Asyncrify(maxConcurrency);
+  for (let i = 0; i < promises.length; i++) {
+    returnArray[i] = new Promise((resolve, reject) => {
+      queue.add(promises[i], (res, err) => {
+        if (err) reject(err);
+        resolve(res);
+      });
+    });
+  }
+  return Promise.all(returnArray);
 }
 
 /**
@@ -54,22 +54,22 @@ async function throttle<T>(
  * author: ahn0min - YeongMin Ahn
  */
 function timeout<T>(promise: Promise<T>, time: number = 8000) {
-    return new Promise((resolve, reject) => {
-        const timeout_id = setTimeout(
-            () => reject(new Error(TimeoutErrors.TIMEOUT_ERROR_MESSAGE)),
-            time
-        );
+  return new Promise((resolve, reject) => {
+    const timeout_id = setTimeout(
+      () => reject(new Error(TimeoutErrors.TIMEOUT_ERROR_MESSAGE)),
+      time
+    );
 
-        promise
-            .then(response => {
-                clearTimeout(timeout_id);
-                resolve(response);
-            })
-            .catch(err => {
-                clearTimeout(timeout_id);
-                reject(err);
-            });
-    });
+    promise
+      .then(response => {
+        clearTimeout(timeout_id);
+        resolve(response);
+      })
+      .catch(err => {
+        clearTimeout(timeout_id);
+        reject(err);
+      });
+  });
 }
 
 /**
@@ -79,8 +79,8 @@ function timeout<T>(promise: Promise<T>, time: number = 8000) {
  * @returns {Promise} - The first promise that is resolved.
  */
 async function race<T>(array_of_promises: Promise<T>[]) {
-    const result = await Promise.race(array_of_promises);
-    return result;
+  const result = await Promise.race(array_of_promises);
+  return result;
 }
 
 export { sleep, timeout, race, TimeoutErrors, throttle };


### PR DESCRIPTION
Scope of change:
I added a throttle method using Asyncrify. there are some caveats though
Key File
promises.ts
Notes
currently asyncrify is designed around callbacks, not returns. I had to do some promiseJitsu to keep the `Promise<T[]>` format for the return value. at the moment I create a new array of promises that handles the callback of asyncrify. these promises are not throttled, but the promises being passed to the throttle method is.
Tricks to help performance with this workaround: 
using an array with a predefined length helps the garbage collector not create a new array on every.push and cleanup the old array.
Downsides to this approach: 
Nested promises is always a code smell.
possible fixes:
I created an issue log for a feature request in asyncrify to support array inputs as well as returns.