### PR TITLE
M0 #4: CI must build + typecheck (guard against a broken artifact)

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -21,5 +21,9 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - run: npm install
+    - run: npm ci
+    - name: Typecheck
+      run: npx tsc --noEmit
+    - name: Build
+      run: npm run compile-files
     - run: npm run production-test


### PR DESCRIPTION
Implements M0 #4 from the roadmap.

CI previously ran only `npm install` + tests, so it never noticed that the published `dist/` was stale and missing half the API.

## Changes (`.github/workflows/node.js.yml`)
- `npm install` → **`npm ci`** for reproducible, lockfile-pinned installs.
- Add a **typecheck** step: `npx tsc --noEmit`.
- Add a **build** step: `npm run compile-files` — a broken build now fails the pipeline, which is the guard against shipping a broken/stale artifact (paired with #1's move to build-on-publish, `dist/` is no longer committed, so building in CI is the check).

Scoped intentionally:
- Kept to the workflow file only (no `package.json` changes) so it doesn't conflict with #1-#3 (PR #67).
- ESLint (`add lint`) is deferred to its dedicated item **#12 (M2)**; this PR uses `tsc --noEmit` as the type gate.
- Node version matrix modernization is **#16 (M2)**.