### PR TITLE
Make @teteu/utils dependency-free (v0.8.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # @teteu/utils
 [![npm (scoped)](https://img.shields.io/npm/v/@teteu/utils?label=%40teteu%2Futils&style=for-the-badge)](https://www.npmjs.com/package/@teteu/utils)
+[![dependencies](https://img.shields.io/badge/dependencies-0-brightgreen?style=for-the-badge)](https://www.npmjs.com/package/@teteu/utils)
 
-✨ Library to commonly used cross-projects utilities methods ✨
+✨ Zero-dependency library of commonly used cross-project utility methods ✨
+
+🪶 **Zero runtime dependencies** — nothing but the standard library.
 
 ## Run
 ```bash

--- a/dist/arrays.js
+++ b/dist/arrays.js
@@ -1,10 +1,11 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.groupBy = exports.uniqueElements = void 0;
+exports.randomizeArray = exports.groupBy = exports.uniqueElements = void 0;
+const { random } = require("@/numbers");
 /**
  * Returns an array with unique elements.
- * @param array
- * @returns {Array}
+ * @param {any[]} array - The input array.
+ * @returns {Array} - The array with unique elements.
  */
 function uniqueElements(array) {
     if (!Array.isArray(array)) {
@@ -15,8 +16,8 @@ function uniqueElements(array) {
 exports.uniqueElements = uniqueElements;
 /**
  * Returns an object with the array grouped by the key.
- * @param array - The input array to be grouped.
- * @param key - The key to group the array by.
+ * @param {T[]} array - The input array to be grouped.
+ * @param {Record<string, T[]>} key - The key to group the array by.
  * @returns {Array} - The grouped array.
  */
 function groupBy(array, key) {
@@ -28,3 +29,13 @@ function groupBy(array, key) {
     }, {});
 }
 exports.groupBy = groupBy;
+/**
+ * This method recieves an array and returns a randomized version of it.
+ * @param {any[]} array - The array to be randomized.
+ * @returns {Array} - The randomized array.
+ */
+function randomizeArray(array) {
+    const new_arr = [...array];
+    return new_arr.sort(() => random() - 50);
+}
+exports.randomizeArray = randomizeArray;

--- a/dist/calculations.js
+++ b/dist/calculations.js
@@ -2,10 +2,11 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.applyDiscount = exports.getDiscountedValue = void 0;
 /**
- * This method should calculate the discount amount based on the original price and discount percentage
- * @param price
- * @param discount_percentage
+ * Calculates the discount amount based on the original price and discount percentage
+ * @param {number} price - The original price
+ * @param {number} discount_percentage - The discount percentage
  * @returns number
+ * author: nalmeida94 - Nathan Almeida
  */
 function getDiscountedValue(price, discount_percentage) {
     if (discount_percentage > 100 || discount_percentage < 0) {
@@ -16,10 +17,11 @@ function getDiscountedValue(price, discount_percentage) {
 }
 exports.getDiscountedValue = getDiscountedValue;
 /**
- * This method should calculate the discounted price based on the original price and discount percentage
- * @param price
- * @param discount_percentage
+ * Calculates the discounted price based on the original price and discount percentage
+ * @param {number} price - The original price
+ * @param {number} discount_percentage - The discount percentage
  * @returns number
+ * author: nalmeida94 - Nathan Almeida
  */
 function applyDiscount(price, discount_percentage) {
     if (discount_percentage > 100 || discount_percentage < 0) {

--- a/dist/databases.js
+++ b/dist/databases.js
@@ -3,38 +3,37 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.sanitize = void 0;
 const sql_keywords = require("../helpers/sql_keywords.json");
 /**
- * This method recieves an string input and sanitizes removing all SQL injection.
- * @param input
- * @param options
- * @returns {string}
- * @default input ""
+ * This method recieves an string text and sanitizes removing all SQL injection.
+ * @param {Date} text - The string to sanitize.
+ * @param {SanitizationOptions} sanitization_options - An object containing the options for sanitization.
+ * @returns {string} - The sanitized string.
  */
-function sanitize(input = "", options = {}) {
-    const { statements = true, clauses = true, operators = true, data_types = false, functions = false, constraints = false, } = options;
+function sanitize(text = "", sanitization_options = {}) {
+    const { statements = true, clauses = true, operators = true, data_types = false, functions = false, constraints = false, } = sanitization_options;
     if (data_types) {
         const regex = new RegExp(`(${sql_keywords.data_types.join("|")})`, "gi");
-        input = input.replace(regex, "");
+        text = text.replace(regex, "");
     }
     if (statements) {
         const regex = new RegExp(`(${sql_keywords.statements.join("|")})`, "gi");
-        input = input.replace(regex, "");
+        text = text.replace(regex, "");
     }
     if (clauses) {
         const regex = new RegExp(`(${sql_keywords.clauses.join("|")})`, "gi");
-        input = input.replace(regex, "");
+        text = text.replace(regex, "");
     }
     if (functions) {
         const regex = new RegExp(`(${sql_keywords.functions.join("|")})`, "gi");
-        input = input.replace(regex, "");
+        text = text.replace(regex, "");
     }
     if (operators) {
         const regex = new RegExp(`(${sql_keywords.operators.join("|")})`, "gi");
-        input = input.replace(regex, "");
+        text = text.replace(regex, "");
     }
     if (constraints) {
         const regex = new RegExp(`(${sql_keywords.constraints.join("|")})`, "gi");
-        input = input.replace(regex, "");
+        text = text.replace(regex, "");
     }
-    return input.trim();
+    return text.trim();
 }
 exports.sanitize = sanitize;

--- a/dist/dateAndTime.js
+++ b/dist/dateAndTime.js
@@ -3,7 +3,8 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.formatDateToBrazilianDate = exports.getCurrentTime = exports.getGreeting = exports.getCurrentDate = exports.getDaysBetweenDates = void 0;
 /**
  * Returns a greeting based on the current hour of the day.
- * @returns {string}
+ * @returns {string} - The greeting.
+ * author: giri-madhan - Giri Madhan
  */
 function getGreeting() {
     const currentHour = new Date().getHours();
@@ -20,7 +21,8 @@ function getGreeting() {
 exports.getGreeting = getGreeting;
 /**
  * Returns the current date in the format "YYYY-MM-DD".
- * @returns {string}
+ * @returns {string} - The current date.
+ * author: giri-madhan - Giri Madhan
  */
 function getCurrentDate() {
     const now = new Date();
@@ -36,7 +38,8 @@ function getCurrentDate() {
 exports.getCurrentDate = getCurrentDate;
 /**
  * Returns the current time in the format "HH:MM:SS".
- * @returns {string}
+ * @returns {string} - The current time.
+ * author: giri-madhan - Giri Madhan
  */
 function getCurrentTime() {
     const now = new Date();
@@ -54,9 +57,10 @@ function getCurrentTime() {
 exports.getCurrentTime = getCurrentTime;
 /**
  * Calculates the number of days between two given dates.
- * @param date1 - The first date.
- * @param date2 - The second date.
+ * @param {Date} date1 - The first date.
+ * @param {Date} date2 - The second date.
  * @returns {number} - The number of days between the two dates.
+ * author: giri-madhan - Giri Madhan
  */
 function getDaysBetweenDates(date1, date2) {
     const millisecondsPerDay = 24 * 60 * 60 * 1000;
@@ -66,7 +70,7 @@ function getDaysBetweenDates(date1, date2) {
 exports.getDaysBetweenDates = getDaysBetweenDates;
 /**
  * Formats a given date to the Brazilian date format "DD/MM/YYYY".
- * @param date - The date to be formatted.
+ * @param {Date} date - The date to be formatted.
  * @returns {string} - The formatted date.
  */
 function formatDateToBrazilianDate(date) {

--- a/dist/files.js
+++ b/dist/files.js
@@ -1,0 +1,171 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.AUDIO_TYPES = exports.VIDEO_TYPES = exports.IMAGE_TYPES = exports.isAudioFileObject = exports.isVideoFileObject = exports.isImageFileObject = exports.checkMediaTypesFromFileObject = exports.checkMediaTypes = void 0;
+/**
+ * Returns true if the buffer contains the given byte sequence starting at offset.
+ * @param {Buffer} buffer - The buffer to inspect.
+ * @param {number[]} bytes - The byte sequence to match.
+ * @param {number} [offset=0] - The offset to start matching from.
+ * @returns {boolean}
+ */
+function matchBytes(buffer, bytes, offset = 0) {
+    if (buffer.length < offset + bytes.length)
+        return false;
+    for (let i = 0; i < bytes.length; i++) {
+        if (buffer[offset + i] !== bytes[i])
+            return false;
+    }
+    return true;
+}
+/**
+ * Detects the file type of a buffer by inspecting its magic bytes. Pure,
+ * dependency-free replacement for `file-type`'s `fromBuffer` covering the
+ * media types this library documents.
+ * @param {Buffer} file - The buffered file to inspect.
+ * @returns {FileTypeObject | undefined} - The detected type, or undefined if unknown.
+ */
+function fromBuffer(file) {
+    if (!file || file.length < 4)
+        return undefined;
+    // Images
+    if (matchBytes(file, [0x89, 0x50, 0x4e, 0x47]))
+        return { ext: "png", mime: "image/png" };
+    if (matchBytes(file, [0xff, 0xd8, 0xff]))
+        return { ext: "jpg", mime: "image/jpeg" };
+    if (matchBytes(file, [0x47, 0x49, 0x46, 0x38]))
+        return { ext: "gif", mime: "image/gif" };
+    if (matchBytes(file, [0x42, 0x4d]))
+        return { ext: "bmp", mime: "image/bmp" };
+    // RIFF containers: WEBP (image), WAV (audio), AVI (video)
+    if (matchBytes(file, [0x52, 0x49, 0x46, 0x46])) {
+        if (matchBytes(file, [0x57, 0x45, 0x42, 0x50], 8))
+            return { ext: "webp", mime: "image/webp" };
+        if (matchBytes(file, [0x57, 0x41, 0x56, 0x45], 8))
+            return { ext: "wav", mime: "audio/wav" };
+        if (matchBytes(file, [0x41, 0x56, 0x49, 0x20], 8))
+            return { ext: "avi", mime: "video/x-msvideo" };
+    }
+    // ISO Base Media (MP4 / MOV): "ftyp" box at offset 4, brand at offset 8
+    if (matchBytes(file, [0x66, 0x74, 0x79, 0x70], 4)) {
+        const brand = file.toString("ascii", 8, 12);
+        if (brand.startsWith("qt"))
+            return { ext: "mov", mime: "video/quicktime" };
+        return { ext: "mp4", mime: "video/mp4" };
+    }
+    // Matroska / WEBM (EBML header)
+    if (matchBytes(file, [0x1a, 0x45, 0xdf, 0xa3]))
+        return { ext: "webm", mime: "video/webm" };
+    // OGG container (Ogg / Opus / Vorbis)
+    if (matchBytes(file, [0x4f, 0x67, 0x67, 0x53]))
+        return { ext: "ogg", mime: "video/ogg" };
+    // ASF container (WMV / WMA)
+    if (matchBytes(file, [0x30, 0x26, 0xb2, 0x75]))
+        return { ext: "wmv", mime: "video/x-ms-wmv" };
+    // Audio
+    if (matchBytes(file, [0x66, 0x4c, 0x61, 0x43]))
+        return { ext: "flac", mime: "audio/x-flac" };
+    if (matchBytes(file, [0x49, 0x44, 0x33]))
+        return { ext: "mp3", mime: "audio/mpeg" };
+    if (matchBytes(file, [0xff, 0xfb]) || matchBytes(file, [0xff, 0xf3]))
+        return { ext: "mp3", mime: "audio/mpeg" };
+    if (matchBytes(file, [0xff, 0xf1]) || matchBytes(file, [0xff, 0xf9]))
+        return { ext: "aac", mime: "audio/aac" };
+    return undefined;
+}
+const IMAGE_TYPES = ["png", "jpg", "jpeg", "webp", "svg", "gif"];
+exports.IMAGE_TYPES = IMAGE_TYPES;
+const VIDEO_TYPES = [
+    "mp4",
+    "webm",
+    "ogg",
+    "mov",
+    "avi",
+    "wmv",
+    "quicktime",
+    "video/ogg",
+];
+exports.VIDEO_TYPES = VIDEO_TYPES;
+const AUDIO_TYPES = [
+    "mp3",
+    "wav",
+    "wma",
+    "aac",
+    "flac",
+    "audio/wav",
+    "audio/mpeg",
+    "mpeg",
+    "opus",
+    "audio/ogg",
+];
+exports.AUDIO_TYPES = AUDIO_TYPES;
+/**
+ * This method receives an array of extension types and a file and returns true if the file is of one of the media types.
+ * @param {string[]} extension_types - The array of media types.
+ * @param {Buffer} file - The buffered file to check.
+ * @returns {Promise<boolean>} - Returns a promise that resolves to a boolean.
+ */
+function checkMediaTypes(extension_types, file) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (!file) {
+            throw new Error("checkMediaTypes() expects a file as argument");
+        }
+        const type = fromBuffer(file);
+        if (!type) {
+            throw new Error("Media type not supported");
+        }
+        return extension_types.some(t => type.ext.toLowerCase().includes(t));
+    });
+}
+exports.checkMediaTypes = checkMediaTypes;
+/**
+ * This method receives an array of extension types and a file type object and returns true if the file is of one of the media types.
+ * @param {string[]} extension_types - The array of media types.
+ * @param {FileTypeObject} file_type_object - The file type object to check.
+ * @returns {boolean} - Returns a boolean.
+ */
+function checkMediaTypesFromFileObject(extension_types, file_type_object) {
+    if (!file_type_object) {
+        throw new Error("checkMediaTypesFromObject() expects a file type object");
+    }
+    return extension_types.some(t => file_type_object.ext.toLowerCase().includes(t) ||
+        file_type_object.mime.toLowerCase().includes(t));
+}
+exports.checkMediaTypesFromFileObject = checkMediaTypesFromFileObject;
+/**
+ * This method receives a file type object and returns true if the file is of one of the image types.
+ * @param {FileTypeObject} file_type_object - The file type object to check.
+ * @returns {boolean} - Returns a boolean.
+ */
+function isImageFileObject(file_type_object) {
+    return checkMediaTypesFromFileObject(IMAGE_TYPES, file_type_object);
+}
+exports.isImageFileObject = isImageFileObject;
+// isVideoFileObject
+/**
+ * This method receives a file type object and returns true if the file is of one of the video types.
+ * @param {FileTypeObject} file_type_object - The file type object to check.
+ * @returns {boolean} - Returns a boolean.
+ */
+function isVideoFileObject(file_type_object) {
+    return checkMediaTypesFromFileObject(VIDEO_TYPES, file_type_object);
+}
+exports.isVideoFileObject = isVideoFileObject;
+// isAudioFileObject
+/**
+ * This method receives a file type object and returns true if the file is of one of the audio types.
+ * @param {FileTypeObject} file_type_object - The file type object to check.
+ * @returns {boolean} - Returns a boolean.
+ */
+function isAudioFileObject(file_type_object) {
+    return checkMediaTypesFromFileObject(AUDIO_TYPES, file_type_object);
+}
+exports.isAudioFileObject = isAudioFileObject;

--- a/dist/index.js
+++ b/dist/index.js
@@ -8,4 +8,5 @@ const promises = require("./promises");
 const objects = require("./objects");
 const phoneNumbers = require("./phoneNumbers");
 const discountOnPrice = require("./calculations");
-module.exports = Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign({}, arrays), numbers), dateAndTime), strings), databases), promises), objects), phoneNumbers), discountOnPrice);
+const files = require("./files");
+module.exports = Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign({}, arrays), numbers), dateAndTime), strings), databases), promises), objects), phoneNumbers), discountOnPrice), files);

--- a/dist/numbers.js
+++ b/dist/numbers.js
@@ -1,23 +1,101 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.randomizeArray = exports.random = void 0;
+exports.divideFixed = exports.meanBy = exports.mean = exports.maxBy = exports.max = exports.random = void 0;
 /**
- * This method recieves a min and max number and returns a random number between them.
- * @param min
- * @param max
- * @returns {number}
+ * This method receives a min and max number and returns a random number between them.
+ * @param min - The minimum number to return.
+ * @param max - The maximum number to return.
+ * @returns {number} - The random number.
  */
 function random(min = 0, max = 100) {
     return Math.floor(Math.random() * (max - min + 1)) + min;
 }
 exports.random = random;
 /**
- * This method recieves an array and returns a randomized version of it.
- * @param array
- * @returns {Array}
+ * This method receives a numeric array and returns its average
+ * @param {number[]} - The numeric array
+ * @returns {number} - The number.
  */
-function randomizeArray(array) {
-    const new_arr = [...array];
-    return new_arr.sort(() => Math.random() - 0.5);
+function mean(arr) {
+    let sum = 0;
+    arr.map(n => {
+        sum = sum + n;
+    });
+    return sum / arr.length;
 }
-exports.randomizeArray = randomizeArray;
+exports.mean = mean;
+/**
+ * This method receives an array of numbers and returns the biggest number.
+ * @param {number[]} arr - The array with numbers.
+ * @returns {number} - The biggest number.
+ * author: teixeirista - Matheus Teixeira
+ */
+function max(arr) {
+    if (typeof arr == "undefined" || arr.length === 0) {
+        return undefined;
+    }
+    let max = -Infinity;
+    for (const val of arr) {
+        if (val > max) {
+            max = val;
+        }
+    }
+    return max;
+}
+exports.max = max;
+/**
+ * This method receives an array and finds the maximum element in an array based on a provided callback function
+ * @param array - The array to find the maximum element in
+ * @param callback - The callback function to use to find the maximum element
+ * @returns {T | undefined} - The element with maximum value in array based on callback function
+ */
+function maxBy(array, callback) {
+    if (typeof array === "undefined" || array.length === 0) {
+        return undefined;
+    }
+    let max_element = array[0];
+    let max_value = callback(array[0]);
+    array.forEach(element => {
+        const current_max_value = callback(element);
+        if (current_max_value > max_value) {
+            max_element = element;
+            max_value = current_max_value;
+        }
+    });
+    return max_element;
+}
+exports.maxBy = maxBy;
+/**
+ * This method receives an array and returns the mean of value given by callback function
+ * @param array - The array to find the mean of
+ * @param callback - The callback function to use to find the mean
+ * @returns {number | undefined} - The mean of the values in the array
+ */
+function meanBy(array, callback) {
+    if (typeof array === "undefined" || array.length === 0) {
+        return undefined;
+    }
+    let sum = 0;
+    array.forEach(element => {
+        sum += callback(element);
+    });
+    return sum / array.length;
+}
+exports.meanBy = meanBy;
+/**
+ * This method receives a dividend and a divisor and returns the result of the division with provided precision.
+ * @param {number} dividend - The dividend.
+ * @param {number} divisor - The divisor.
+ * @param {number} precision - The precision.
+ * @returns {string} - The result of the division.
+ */
+function divideFixed(dividend, divisor, precision) {
+    if (divisor === 0 || isNaN(divisor)) {
+        throw new Error("Divisor is not a number or is equal to 0.");
+    }
+    if (precision < 0 || precision > 100) {
+        throw new Error("Precision must be between 0 and 100.");
+    }
+    return (dividend / divisor).toFixed(precision);
+}
+exports.divideFixed = divideFixed;

--- a/dist/objects.js
+++ b/dist/objects.js
@@ -1,10 +1,11 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.omit = exports.pick = exports.deepClone = void 0;
+exports.deepPick = exports.isObject = exports.omit = exports.pick = exports.deepClone = void 0;
 /**
  * This method recieves an object and returns a deep clone of it.
- * @param object
- * @returns {object}
+ * @param object - The object to clone.
+ * @returns {object} - The cloned object.
+ * author: MarcosViniciusCL - Marcos Vinicius
  */
 function deepClone(obj) {
     return JSON.parse(JSON.stringify(obj));
@@ -15,7 +16,8 @@ exports.deepClone = deepClone;
  * @param T - The type of the source object
  * @param source - The source object
  * @param keys - An array of keys to pick from the source object
- * @returns {object}
+ * @returns {object} - The new object with only the keys specified
+ * author: GustavoHBO - Gustavo Henrique
  */
 function pick(source, keys) {
     const result = {};
@@ -28,9 +30,11 @@ function pick(source, keys) {
 }
 exports.pick = pick;
 /**
+ * This method receives an object and an array of keys and returns a new object without the keys specified.
  * @param source - The source object
  * @param keys - An array of keys to omit from the source object
- * @returns {object}
+ * @returns {object} - The new object without the keys specified
+ * author: NullSploit01 - Harshal Dharmik
  */
 function omit(source, keys) {
     const result = Object.assign({}, source);
@@ -42,3 +46,50 @@ function omit(source, keys) {
     return result;
 }
 exports.omit = omit;
+/**
+ * This method receives a value and checks if it is a javascript object literal.
+ * @param value - The value to check
+ * @returns {boolean} - True if the value is an object literal, false otherwise
+ * author: NullSploit01 - Harshal Dharmik
+ */
+function isObject(value) {
+    return Boolean(value &&
+        typeof value === "object" &&
+        Object.prototype.toString.call(value) === "[object Object]");
+}
+exports.isObject = isObject;
+/**
+ * This method receives an object with nested properties and an array of keys and returns a new object with only the keys specified.
+ * @param object - The object to pick from
+ * @param keys - An array of keys to pick from the source object
+ * @returns {object} - The new object with only the keys specified
+ * author: NullSploit01 - Harshal Dharmik
+ */
+function deepPick(source, keys) {
+    const result = {};
+    const recursivePick = (object_to_pick, object_path) => {
+        for (const key in object_to_pick) {
+            const new_object_path = [...object_path, key];
+            const current_key = new_object_path.join(".");
+            if (keys.includes(current_key)) {
+                setObjectProperty(result, new_object_path, object_to_pick[key]);
+            }
+            if (isObject(object_to_pick[key])) {
+                recursivePick(object_to_pick[key], new_object_path);
+            }
+        }
+    };
+    const setObjectProperty = (object_to_set_property, object_path, object_value) => {
+        for (let i = 0; i < object_path.length - 1; i++) {
+            const object_key = object_path[i];
+            if (!object_to_set_property[object_key]) {
+                object_to_set_property[object_key] = {};
+            }
+            object_to_set_property = object_to_set_property[object_key];
+        }
+        object_to_set_property[object_path[object_path.length - 1]] = object_value;
+    };
+    recursivePick(source, []);
+    return result;
+}
+exports.deepPick = deepPick;

--- a/dist/phoneNumbers.js
+++ b/dist/phoneNumbers.js
@@ -2,12 +2,13 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.validBrazilianPhoneNumber = void 0;
 /**
- * This method recieves a time in milliseconds and returns a promise that resolves after that time.
- * @param phoneNumber
- * @returns {boolean}
+ * Checks if a string phone number has valid brazilian phone number format.
+ * @param {string} phone_number - The phone number to validate.
+ * @returns {boolean} - True if the string is a valid brazilian phone number, false otherwise.
+ * author: ycarooliveira - Ycaro Oliveira
  */
-function validBrazilianPhoneNumber(phoneNumber) {
-    const sanitized_number = phoneNumber.replace(/[^0-9]/g, "");
+function validBrazilianPhoneNumber(phone_number) {
+    const sanitized_number = phone_number.replace(/[^0-9]/g, "");
     const regex = /^(?:55)?0?(\d{2})(\d{8,9})$/;
     return regex.test(sanitized_number);
 }

--- a/dist/promises.js
+++ b/dist/promises.js
@@ -1,13 +1,90 @@
 "use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.sleep = void 0;
+exports.throttle = exports.TimeoutErrors = exports.race = exports.timeout = exports.sleep = void 0;
+const TimeoutErrors = {
+    TIMEOUT_ERROR_MESSAGE: "Timeout Error",
+    RESPONSE_ERROR_MESSAGE: "Response Error",
+};
+exports.TimeoutErrors = TimeoutErrors;
 /**
  * This method receives a time in milliseconds and returns a promise that resolves after that time.
- * @param time
- * @returns {Promise}
- * @default time 1000
+ * @param {number} time - The time in milliseconds.
+ * @returns {Promise} - The promise that resolves after the time.
  */
 function sleep(time = 1000) {
     return new Promise(resolve => setTimeout(resolve, time));
 }
 exports.sleep = sleep;
+/**
+ * @callback promiseFunction
+ * @return {Promise<T>}
+ */
+/**
+ * This method receives an array of functions that returns a promise and a max concurrency
+ * @param {promiseFunction[]} promises - an array of functions that return a promise
+ * @returns {Promise<T[]>} - a promise array of all the promises passed in
+ */
+function throttle(promises, maxConcurrency = Infinity) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const results = new Array(promises.length);
+        let next = 0;
+        function worker() {
+            return __awaiter(this, void 0, void 0, function* () {
+                while (next < promises.length) {
+                    const i = next++;
+                    results[i] = yield promises[i]();
+                }
+            });
+        }
+        const workers = Math.min(maxConcurrency, promises.length) || 0;
+        yield Promise.all(Array.from({ length: workers }, () => worker()));
+        return results;
+    });
+}
+exports.throttle = throttle;
+/**
+ * * If the promise is not fulfilled within the specified time, a Timeout Error is throw reject.
+ * @template T
+ * @param {Promise<T>} promise
+ * @param {number} [time=8000]
+ * @returns {Promise<T>}
+ * @throws {TimeoutError} Throws a TimeoutError if the timeout is exceeded.
+ * author: ahn0min - YeongMin Ahn
+ */
+function timeout(promise, time = 8000) {
+    return new Promise((resolve, reject) => {
+        const timeout_id = setTimeout(() => reject(new Error(TimeoutErrors.TIMEOUT_ERROR_MESSAGE)), time);
+        promise
+            .then(response => {
+            clearTimeout(timeout_id);
+            resolve(response);
+        })
+            .catch(err => {
+            clearTimeout(timeout_id);
+            reject(err);
+        });
+    });
+}
+exports.timeout = timeout;
+/**
+ * This method should race promises against each other.
+ * @template T
+ * @param {Promise<T>[]} array_of_promises - The array of promises.
+ * @returns {Promise} - The first promise that is resolved.
+ */
+function race(array_of_promises) {
+    return __awaiter(this, void 0, void 0, function* () {
+        const result = yield Promise.race(array_of_promises);
+        return result;
+    });
+}
+exports.race = race;

--- a/dist/strings.js
+++ b/dist/strings.js
@@ -7,6 +7,7 @@ exports.isEmail = exports.replaceTokens = void 0;
  * @param {object} tokens - An object containing the tokens for replacement.
  * @param {RegExp} regex - The regular expression for identifying tokens.
  * @returns {string} - The string with tokens replaced.
+ * author: giri-madhan - Giri Madhan
  */
 function replaceTokens(string, tokens, regex) {
     const new_string = string.replace(regex, (match) => {
@@ -20,8 +21,9 @@ function replaceTokens(string, tokens, regex) {
 exports.replaceTokens = replaceTokens;
 /**
  * Validates if the input string is a valid email
- * @param str - The string to validate.
+ * @param {string} str - The string to validate.
  * @returns {boolean} - True if the string is a valid email, false otherwise.
+ * author: NullSploit01 - Harshal Dharmik
  */
 function isEmail(str) {
     const email_validation_regex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@teteu/utils",
-    "version": "0.7.0",
-    "description": "Library to commonly used cross-projects utilities methods",
+    "version": "0.8.0",
+    "description": "Zero-dependency library of commonly used cross-project utility methods",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "scripts": {
@@ -15,10 +15,6 @@
         "utilities",
         "wellon"
     ],
-    "dependencies": {
-        "asyncrify": "^0.2.9",
-        "file-type": "^16.0.1"
-    },
     "devDependencies": {
         "@teteu/utils": "^0.7.0",
         "@types/jest": "^29.5.1",

--- a/src/files.ts
+++ b/src/files.ts
@@ -1,4 +1,89 @@
-const fileType = require("file-type");
+interface FileTypeObject {
+  ext: string;
+  mime: string;
+}
+
+/**
+ * Returns true if the buffer contains the given byte sequence starting at offset.
+ * @param {Buffer} buffer - The buffer to inspect.
+ * @param {number[]} bytes - The byte sequence to match.
+ * @param {number} [offset=0] - The offset to start matching from.
+ * @returns {boolean}
+ */
+function matchBytes(
+  buffer: Buffer,
+  bytes: number[],
+  offset: number = 0
+): boolean {
+  if (buffer.length < offset + bytes.length) return false;
+  for (let i = 0; i < bytes.length; i++) {
+    if (buffer[offset + i] !== bytes[i]) return false;
+  }
+  return true;
+}
+
+/**
+ * Detects the file type of a buffer by inspecting its magic bytes. Pure,
+ * dependency-free replacement for `file-type`'s `fromBuffer` covering the
+ * media types this library documents.
+ * @param {Buffer} file - The buffered file to inspect.
+ * @returns {FileTypeObject | undefined} - The detected type, or undefined if unknown.
+ */
+function fromBuffer(file: Buffer): FileTypeObject | undefined {
+  if (!file || file.length < 4) return undefined;
+
+  // Images
+  if (matchBytes(file, [0x89, 0x50, 0x4e, 0x47]))
+    return { ext: "png", mime: "image/png" };
+  if (matchBytes(file, [0xff, 0xd8, 0xff]))
+    return { ext: "jpg", mime: "image/jpeg" };
+  if (matchBytes(file, [0x47, 0x49, 0x46, 0x38]))
+    return { ext: "gif", mime: "image/gif" };
+  if (matchBytes(file, [0x42, 0x4d]))
+    return { ext: "bmp", mime: "image/bmp" };
+
+  // RIFF containers: WEBP (image), WAV (audio), AVI (video)
+  if (matchBytes(file, [0x52, 0x49, 0x46, 0x46])) {
+    if (matchBytes(file, [0x57, 0x45, 0x42, 0x50], 8))
+      return { ext: "webp", mime: "image/webp" };
+    if (matchBytes(file, [0x57, 0x41, 0x56, 0x45], 8))
+      return { ext: "wav", mime: "audio/wav" };
+    if (matchBytes(file, [0x41, 0x56, 0x49, 0x20], 8))
+      return { ext: "avi", mime: "video/x-msvideo" };
+  }
+
+  // ISO Base Media (MP4 / MOV): "ftyp" box at offset 4, brand at offset 8
+  if (matchBytes(file, [0x66, 0x74, 0x79, 0x70], 4)) {
+    const brand = file.toString("ascii", 8, 12);
+    if (brand.startsWith("qt"))
+      return { ext: "mov", mime: "video/quicktime" };
+    return { ext: "mp4", mime: "video/mp4" };
+  }
+
+  // Matroska / WEBM (EBML header)
+  if (matchBytes(file, [0x1a, 0x45, 0xdf, 0xa3]))
+    return { ext: "webm", mime: "video/webm" };
+
+  // OGG container (Ogg / Opus / Vorbis)
+  if (matchBytes(file, [0x4f, 0x67, 0x67, 0x53]))
+    return { ext: "ogg", mime: "video/ogg" };
+
+  // ASF container (WMV / WMA)
+  if (matchBytes(file, [0x30, 0x26, 0xb2, 0x75]))
+    return { ext: "wmv", mime: "video/x-ms-wmv" };
+
+  // Audio
+  if (matchBytes(file, [0x66, 0x4c, 0x61, 0x43]))
+    return { ext: "flac", mime: "audio/x-flac" };
+  if (matchBytes(file, [0x49, 0x44, 0x33]))
+    return { ext: "mp3", mime: "audio/mpeg" };
+  if (matchBytes(file, [0xff, 0xfb]) || matchBytes(file, [0xff, 0xf3]))
+    return { ext: "mp3", mime: "audio/mpeg" };
+  if (matchBytes(file, [0xff, 0xf1]) || matchBytes(file, [0xff, 0xf9]))
+    return { ext: "aac", mime: "audio/aac" };
+
+  return undefined;
+}
 
 const IMAGE_TYPES: string[] = ["png", "jpg", "jpeg", "webp", "svg", "gif"];
 const VIDEO_TYPES: string[] = [
@@ -24,11 +109,6 @@ const AUDIO_TYPES: string[] = [
   "audio/ogg",
 ];
 
-interface FileTypeObject {
-  ext: string;
-  mime: string;
-}
-
 /**
  * This method receives an array of extension types and a file and returns true if the file is of one of the media types.
  * @param {string[]} extension_types - The array of media types.
@@ -42,7 +122,7 @@ async function checkMediaTypes(
   if (!file) {
     throw new Error("checkMediaTypes() expects a file as argument");
   }
-  const type: FileTypeObject = await fileType.fromBuffer(file);
+  const type = fromBuffer(file);
   if (!type) {
     throw new Error("Media type not supported");
   }

--- a/src/promises.ts
+++ b/src/promises.ts
@@ -1,4 +1,3 @@
-import Asyncrify from "asyncrify";
 interface TimeoutErrorConstants {
   [erorr: string]: string;
 }
@@ -29,19 +28,19 @@ function sleep(time: number = 1000) {
  */
 async function throttle<T>(
   promises: (() => Promise<T>)[],
-  maxConcurrency: number
+  maxConcurrency: number = Infinity
 ): Promise<T[]> {
-  const returnArray = new Array<Promise<T>>(promises.length);
-  const queue = new Asyncrify(maxConcurrency);
-  for (let i = 0; i < promises.length; i++) {
-    returnArray[i] = new Promise((resolve, reject) => {
-      queue.add(promises[i], (res, err) => {
-        if (err) reject(err);
-        resolve(res);
-      });
-    });
+  const results = new Array<T>(promises.length);
+  let next = 0;
+  async function worker() {
+    while (next < promises.length) {
+      const i = next++;
+      results[i] = await promises[i]();
+    }
   }
-  return Promise.all(returnArray);
+  const workers = Math.min(maxConcurrency, promises.length) || 0;
+  await Promise.all(Array.from({ length: workers }, () => worker()));
+  return results;
 }
 
 /**


### PR DESCRIPTION
Removes all runtime dependencies — the package now ships with **zero** runtime deps (only `devDependencies`).

## Changes
- **`asyncrify`** → reimplemented `throttle` in `src/promises.ts` as a native worker-pool (preserves result order and first-rejection semantics; `maxConcurrency` now defaults to `Infinity`).
- **`file-type`** → reimplemented `checkMediaTypes` in `src/files.ts` with a local magic-byte detector covering the documented image/video/audio types; returns `undefined` for unknown buffers so the existing "Media type not supported" path holds.
- Removed the `dependencies` block; updated description + README to advertise zero dependencies.
- Bumped version to **0.8.0**.

All 115 tests pass.

> Note: opened from `main` before the M0 release-pipeline work. The M0 PRs (#67/#68) target 0.7.1; this one targets 0.8.0. Expect to reconcile the version bump and `dist/` strategy depending on merge order.