### PR TITLE
chore: fill packaging metadata and README gaps

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Matheus Rodrigues
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -21,59 +21,59 @@ utils.random(10, 20); // should return a random number between 10 and 20
 ```
 ## Methods Docs
 ### Arrays
-|Method|What It Does|Parameters|Return|Example|
-|-|-|-|-|-|
-|uniqueElements|returns an array with unique elements|(array)|array with unique elements|[here]()|
-|groupBy|receives an array of objects and returns a grouped by object|(array of literal object, key) |object with keys being the values of array[i][key]|[here]()|
-|randomizeArray|recieves an array and returns a randomized version of it|(array to randomize)|randomized array|[here]()|
+|Method|What It Does|Parameters|Return|
+|-|-|-|-|
+|uniqueElements|returns an array with unique elements|(array)|array with unique elements|
+|groupBy|receives an array of objects and returns a grouped by object|(array of literal object, key) |object with keys being the values of array[i][key]|
+|randomizeArray|recieves an array and returns a randomized version of it|(array to randomize)|randomized array|
 ### Promises
-|Method|What It Does|Parameters|Return|Example|
-|-|-|-|-|-|
-|sleep|pretty much sleeps until the specified time passes|(time in milliseconds)|Promise|[here]()|
+|Method|What It Does|Parameters|Return|
+|-|-|-|-|
+|sleep|pretty much sleeps until the specified time passes|(time in milliseconds)|Promise|
 ### Strings
-|Method|What It Does|Parameters|Return|Example|
-|-|-|-|-|-|
-|replaceTokens|replace tokens in a string based on a custom regular expression|(string, tokens and regex)|new string with tokens replaced|[here]()|
-|isEmail|validates if the input string is a valid email|(string)|True if the string is a valid email, false otherwise.|[here]()|
+|Method|What It Does|Parameters|Return|
+|-|-|-|-|
+|replaceTokens|replace tokens in a string based on a custom regular expression|(string, tokens and regex)|new string with tokens replaced|
+|isEmail|validates if the input string is a valid email|(string)|True if the string is a valid email, false otherwise.|
 ### Phone Numbers
-|Method|What It Does|Parameters|Return|Example|
-|-|-|-|-|-|
-|validBrazilianPhoneNumber|Checks if a string phone number has valid brazilian phone number format|(string phone number)|True if the string is a valid brazilian phone number, false otherwise|[here]()|
+|Method|What It Does|Parameters|Return|
+|-|-|-|-|
+|validBrazilianPhoneNumber|Checks if a string phone number has valid brazilian phone number format|(string phone number)|True if the string is a valid brazilian phone number, false otherwise|
 ### Numbers
-|Method|What It Does|Parameters|Return|Example|
-|-|-|-|-|-|
-|random|receives a min and max number and returns a random number between them|(min, max)|random number between min-max|[here]()|
-|mean|receives a numeric array and returns its average|(arr)|the average|[here]()|
-|max|receives an array of numbers and returns the biggest number|(arr of numbers)|the biggest number or undefined|[here]()|
-|maxBy|receives an array and finds the maximum element in an array based on a provided callback function|(array, callback)|element with maximum value in array based on callback function|[here]()|
-|divideFixed|receives a number, divisor and precision and returns the result of the division with provided precision|(dividend, divisor, precision)|result of the division with provided precision|[here]()|
-|meanBy|receives an array and returns the mean of value given by callback function|(array, callback)|The mean of the values given by callback function from the array|[here]()|
+|Method|What It Does|Parameters|Return|
+|-|-|-|-|
+|random|receives a min and max number and returns a random number between them|(min, max)|random number between min-max|
+|mean|receives a numeric array and returns its average|(arr)|the average|
+|max|receives an array of numbers and returns the biggest number|(arr of numbers)|the biggest number or undefined|
+|maxBy|receives an array and finds the maximum element in an array based on a provided callback function|(array, callback)|element with maximum value in array based on callback function|
+|divideFixed|receives a number, divisor and precision and returns the result of the division with provided precision|(dividend, divisor, precision)|result of the division with provided precision|
+|meanBy|receives an array and returns the mean of value given by callback function|(array, callback)|The mean of the values given by callback function from the array|
 ### Date And Time
-|Method|What It Does|Parameters|Return|Example|
-|-|-|-|-|-|
-|getGreeting|Returns a greeting based on the current hour of the day|void|greeting string|[here]()|
-|getCurrentDate| Returns the current date in the format "YYYY-MM-DD"|void|current date|[here]()|
-|getCurrentTime|Returns the current time in the format "HH:MM:SS"|void|current time|[here]()|
-|getDaysBetweenDates|Calculates the number of days between two given dates|(date1, date2)|number of days between the two dates|[here]()|
-|formatDateToBrazilianDate|Formats a given date to the Brazilian date format "DD/MM/YYYY"|(date)|formatted date string|[here]()|
+|Method|What It Does|Parameters|Return|
+|-|-|-|-|
+|getGreeting|Returns a greeting based on the current hour of the day|void|greeting string|
+|getCurrentDate| Returns the current date in the format "YYYY-MM-DD"|void|current date|
+|getCurrentTime|Returns the current time in the format "HH:MM:SS"|void|current time|
+|getDaysBetweenDates|Calculates the number of days between two given dates|(date1, date2)|number of days between the two dates|
+|formatDateToBrazilianDate|Formats a given date to the Brazilian date format "DD/MM/YYYY"|(date)|formatted date string|
 ### Databases
-|Method|What It Does|Parameters|Return|Example|
-|-|-|-|-|-|
-|sanitize|This method recieves an string input and sanitizes removing all SQL injection|(string to sanitize and optionally an object containing the options for sanitization, check Example for better understanding)|sanitized string|[here]()|
+|Method|What It Does|Parameters|Return|
+|-|-|-|-|
+|sanitize|This method recieves an string input and sanitizes removing all SQL injection|(string to sanitize and optionally an object containing the options for sanitization)|sanitized string|
 ### Calculations
-|Method|What It Does|Parameters|Return|Example|
-|-|-|-|-|-|
-|getDiscountedValue|Calculate the discount amount based on the original price and discount percentage|(price, discount percentage [0 - 100])|discounted value|[here]()|
-|applyDiscount|Calculates the discounted price based on the original price and discount percentage|(price, discount percentage)|result of price after discount|[here]()|
+|Method|What It Does|Parameters|Return|
+|-|-|-|-|
+|getDiscountedValue|Calculate the discount amount based on the original price and discount percentage|(price, discount percentage [0 - 100])|discounted value|
+|applyDiscount|Calculates the discounted price based on the original price and discount percentage|(price, discount percentage)|result of price after discount|
 
 ### Objects
-|Method|What It Does|Parameters|Return|Example|
-|-|-|-|-|-|
-|deepClone|recieves an object and returns a deep clone of it|(object to clone)|cloned object|[here]()|
-|pick|receives an object and an array of keys and returns a new object with only the keys specified|(source object and array of keys to pick from the source object)|new object with only the keys specified|[here]()|
-|omit|receives an object and an array of keys and returns a new object without the keys specified|(source object and array of keys to omit from the source object)|new object without the keys specified|[here]()|
-|isObject|receives a value and checks if it is a javascript object literal|(value to check)|boolean|[here]()|
-|deepPick| receives an object with nested properties and an array of keys and returns a new object with only the keys specified.|(source object and array of keys)|new object with only the keys specified|[here]()|
+|Method|What It Does|Parameters|Return|
+|-|-|-|-|
+|deepClone|recieves an object and returns a deep clone of it|(object to clone)|cloned object|
+|pick|receives an object and an array of keys and returns a new object with only the keys specified|(source object and array of keys to pick from the source object)|new object with only the keys specified|
+|omit|receives an object and an array of keys and returns a new object without the keys specified|(source object and array of keys to omit from the source object)|new object without the keys specified|
+|isObject|receives a value and checks if it is a javascript object literal|(value to check)|boolean|
+|deepPick| receives an object with nested properties and an array of keys and returns a new object with only the keys specified.|(source object and array of keys)|new object with only the keys specified|
 ## Development
 This project uses [Bun](https://bun.sh) as its primary runtime, [Biome](https://biomejs.dev) for linting/formatting, and TypeScript (the package is still published as CommonJS for npm consumers).
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ utils.random(10, 20); // should return a random number between 10 and 20
 |Method|What It Does|Parameters|Return|
 |-|-|-|-|
 |sleep|pretty much sleeps until the specified time passes|(time in milliseconds)|Promise|
+|throttle|runs an array of promise-returning functions, capping how many run at once|(array of functions returning promises, max concurrency = Infinity)|Promise of the array of results|
+|timeout|rejects with a Timeout Error if the promise does not settle within the given time|(promise, time in milliseconds = 8000)|the resolved value, or rejects with a Timeout Error|
+|race|races the given promises against each other|(array of promises)|the first promise to settle|
 ### Strings
 |Method|What It Does|Parameters|Return|
 |-|-|-|-|

--- a/README.md
+++ b/README.md
@@ -19,6 +19,23 @@ const utils = require('@teteu/utils');
 
 utils.random(10, 20); // should return a random number between 10 and 20
 ```
+
+## Development
+This project uses [Bun](https://bun.sh) as its primary runtime, [Biome](https://biomejs.dev) for linting/formatting, and TypeScript (the package is still published as CommonJS for npm consumers).
+
+```bash
+bun install          # install dependencies
+bun test             # run the test suite
+bun run test:watch   # run tests in watch mode
+bun run lint         # lint + format (writes fixes)
+bun run check        # lint + format check (no writes, used in CI)
+bun run typecheck    # tsc --noEmit
+bun run compile-files # build to dist/
+```
+
+## Contribute
+Feel free to contribute. Check if we have open issues or request your utility method. Your code here is very welcome 🤝🤝
+
 ## Methods Docs
 ### Arrays
 |Method|What It Does|Parameters|Return|
@@ -77,19 +94,4 @@ utils.random(10, 20); // should return a random number between 10 and 20
 |omit|receives an object and an array of keys and returns a new object without the keys specified|(source object and array of keys to omit from the source object)|new object without the keys specified|
 |isObject|receives a value and checks if it is a javascript object literal|(value to check)|boolean|
 |deepPick| receives an object with nested properties and an array of keys and returns a new object with only the keys specified.|(source object and array of keys)|new object with only the keys specified|
-## Development
-This project uses [Bun](https://bun.sh) as its primary runtime, [Biome](https://biomejs.dev) for linting/formatting, and TypeScript (the package is still published as CommonJS for npm consumers).
-
-```bash
-bun install          # install dependencies
-bun test             # run the test suite
-bun run test:watch   # run tests in watch mode
-bun run lint         # lint + format (writes fixes)
-bun run check        # lint + format check (no writes, used in CI)
-bun run typecheck    # tsc --noEmit
-bun run compile-files # build to dist/
-```
-
-## Contribute
-Feel free to contribute. Check if we have open issues or request your utility method. Your code here is very welcome 🤝🤝
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,14 @@
     "utils",
     "utilities"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/matheus-rodrigues00/utils.git"
+  },
+  "bugs": {
+    "url": "https://github.com/matheus-rodrigues00/utils/issues"
+  },
+  "homepage": "https://github.com/matheus-rodrigues00/utils#readme",
   "files": [
     "dist",
     "helpers",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@teteu/utils",
   "version": "0.9.0",
   "description": "Zero-dependency library of commonly used cross-project utility methods",
+  "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
Closes the packaging/docs gaps from the roadmap (M2 #18): the package had no license and incomplete metadata, and the README method tables had dead links and missing methods.

### Changes
- **Add MIT license** — new `LICENSE` file + `"license": "MIT"` in `package.json`, so the package is no longer implicitly all-rights-reserved.
- **Complete package metadata** — add `repository`, `bugs`, and `homepage` so the npm page links to the source, issues, and README.
- **Drop empty example links** — every `Example` cell in the README tables was an empty `[here]()` link; removed the column until real examples exist.
- **Document `throttle`, `timeout`, and `race`** — these exported promise utilities were missing from the Promises table.
- **Surface contribution guidance** — move the Development and Contribute sections above the long Methods Docs tables so contributors find setup instructions first.

Split into commits, one per logical change.

### Notes
- The package stays zero-dependency; no source or runtime behaviour changed.
- `bun run check` passes; `npm pack --dry-run` confirms `LICENSE` ships in the tarball.
