### PR TITLE
chore: ignore markdown and mdc files except README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@ coverage.*
 **/.vscode
 **/.idea
 **/todo.txt
+
+
+*.mdc
+*.md
+!README.md


### PR DESCRIPTION
Ignore `*.md` and `*.mdc` files (keeping `README.md` tracked) so local notes and Cursor rule files don't get committed.

Already-tracked Markdown files (CONTRIBUTING.md, CLAUDE.md, etc.) are unaffected — this only prevents new `.md`/`.mdc` files from being added by mistake.