### PR TITLE
fix: preserve timeout generic type

### DIFF
--- a/__tests__/promises-type.test.ts
+++ b/__tests__/promises-type.test.ts
@@ -1,0 +1,10 @@
+import { timeout } from "../src/promises";
+
+const assert_timeout_preserves_generic = () => {
+  const number_timeout: Promise<number> = timeout(Promise.resolve(42));
+  const string_timeout: Promise<string> = timeout(Promise.resolve("resolved"));
+
+  return [number_timeout, string_timeout] as const;
+};
+
+void assert_timeout_preserves_generic;

--- a/__tests__/promises-type.test.ts
+++ b/__tests__/promises-type.test.ts
@@ -1,10 +1,15 @@
-import { timeout } from "../src/promises";
+import { timeout } from "@/promises";
 
-const assert_timeout_preserves_generic = () => {
-  const number_timeout: Promise<number> = timeout(Promise.resolve(42));
-  const string_timeout: Promise<string> = timeout(Promise.resolve("resolved"));
+// Guards #75: timeout<T> must preserve T (it used to widen to Promise<unknown>
+// and drop the generic). The explicit `number`/`string` annotations on the
+// awaited results double as a compile-time check — they stop compiling under
+// `bun run typecheck` if the generic is ever dropped again.
+describe("timeout generic preservation", () => {
+  test("preserves the resolved type and value of the input promise", async () => {
+    const num: number = await timeout(Promise.resolve(42));
+    const str: string = await timeout(Promise.resolve("resolved"));
 
-  return [number_timeout, string_timeout] as const;
-};
-
-void assert_timeout_preserves_generic;
+    expect(num).toBe(42);
+    expect(str).toBe("resolved");
+  });
+});

--- a/src/promises.ts
+++ b/src/promises.ts
@@ -52,8 +52,8 @@ async function throttle<T>(
  * @throws {TimeoutError} Throws a TimeoutError if the timeout is exceeded.
  * author: ahn0min - YeongMin Ahn
  */
-function timeout<T>(promise: Promise<T>, time: number = 8000) {
-  return new Promise((resolve, reject) => {
+function timeout<T>(promise: Promise<T>, time: number = 8000): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
     const timeout_id = setTimeout(
       () => reject(new Error(TimeoutErrors.TIMEOUT_ERROR_MESSAGE)),
       time


### PR DESCRIPTION
Scope of change:
Fixes the public TypeScript contract for `timeout<T>` so the returned promise keeps the input promise generic instead of widening to `Promise<unknown>`.

Key File
`src/promises.ts`
`__tests__/promises-type.test.ts`

Notes
Closes #75.

Verification:
- `bun install --frozen-lockfile`
- `bun test` (115 passed, 0 failed)
- `bun run production-test` (115 passed, 0 failed)
- `bun run typecheck`
- `bun run check`
- `bun run compile-files`
- Targeted compiled runtime smoke for resolve and timeout rejection behavior