### PR TITLE
fix: return undefined from mean([]) instead of NaN

### DIFF
--- a/__tests__/numbers.test.ts
+++ b/__tests__/numbers.test.ts
@@ -93,6 +93,14 @@ describe("mean", () => {
     expect(result).not.toBeGreaterThan(2.5);
     expect(result).not.toBeLessThan(2.5);
   });
+
+  test("should return undefined for an empty array", () => {
+    const arr: number[] = [];
+
+    const result = mean(arr);
+
+    expect(result).toBeUndefined();
+  });
 });
 
 describe("divideFixed", () => {

--- a/src/numbers.ts
+++ b/src/numbers.ts
@@ -10,16 +10,15 @@ function random(min: number = 0, max: number = 100): number {
 
 /**
  * This method receives a numeric array and returns its average
- * @param {number[]} - The numeric array
- * @returns {number} - The number.
+ * @param {number[]} arr - The numeric array
+ * @returns {number | undefined} - The average, or undefined for an empty array.
  */
-function mean(arr: number[]): number {
-  let sum: number = 0;
-  arr.forEach(n => {
-    sum = sum + n;
-  });
+function mean(arr: number[]): number | undefined {
+  if (arr.length === 0) {
+    return undefined;
+  }
 
-  return sum / arr.length;
+  return arr.reduce((sum, n) => sum + n, 0) / arr.length;
 }
 
 /**


### PR DESCRIPTION
## Scope of change
Fixes `mean([])` returning `NaN` by adding an empty-array guard that returns `undefined`, consistent with `max`, `maxBy`, and `meanBy`.

## Key File
- `src/numbers.ts` — added early return for empty input, replaced `forEach` + mutable sum with `reduce`
- `__tests__/numbers.test.ts` — added test case for empty array

## Notes
Fixes #73

- `mean([])` now returns `undefined` instead of `NaN`
- Uses `arr.reduce((sum, n) => sum + n, 0)` instead of `forEach` with mutable variable
- Return type changed from `number` to `number | undefined`
- JSDoc updated to reflect the new behavior